### PR TITLE
Add math functions to sandbox

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -1,7 +1,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:           Lmod
-Version:        8.3.17
+Version:        8.3.18
 Release:        1.br%{?dist}
 Summary:        Environmental Modules System in Lua
 
@@ -97,6 +97,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Jun 29 2020 Alex Domingo <alex.domingo.toro@vub.be>
+- Add math.ceil, math.max and math.min to sandbox
+- bump to 8.3.18
+
 * Wed Jun 17 2020 Ward Poelmans <ward.poelmans@vub.be>
 - Added get_avail_memory function to module sandbox
 - Add math.floor to sandbox

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -278,4 +278,10 @@ hook.register("isVisibleHook", visible_hook)
 
 sandbox_registration{
     get_avail_memory = get_avail_memory,
+    math = {
+        floor = math.floor,
+        ceil = math.ceil,
+        max = math.max,
+        min = math.min,
+    },
 }


### PR DESCRIPTION
According to the documentation of Lmod (https://lmod.readthedocs.io/en/latest/050_lua_modulefiles.html#math-functions), these 4 math functions should be available in the sandbox.