### PR TITLE
JupyterHub modules have no use for users (AB#14720)

### DIFF
--- a/Lmod-UGent.spec
+++ b/Lmod-UGent.spec
@@ -2,7 +2,7 @@
 
 Name:           Lmod
 Version:        8.7.6
-Release:        1.br%{?dist}
+Release:        2.br%{?dist}
 Summary:        Environmental Modules System in Lua
 
 # Lmod-5.3.2/tools/base64.lua is LGPLv2
@@ -98,6 +98,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Nov 07 2022 Alex Domingo <alex.domingo.toro@vub.be>
+- Hide JupyterHub modules
+
 * Mon Jun 13 2022 Samuel Moors <samuel.moors@vub.be>
 - Fix HPC email
 

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -234,6 +234,8 @@ local function visible_hook(modT)
         modT.isVisible = false
     elseif modT.fullName:find("EESSI/") then
         modT.isVisible = false
+    elseif modT.fullName:find("JupyterHub/") then
+        modT.isVisible = false
     elseif module_age(modT) > 5 then
         modT.isVisible = false
     end


### PR DESCRIPTION
Related to INC0129724, where a user was trying to start JupyterHub on his own, which will never work. The module of jupyterHub is only needed to talk back to the actual JupyterHub instance from the compute node.